### PR TITLE
Added manifest file for progressive web app

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,13 +1,17 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" href="%sveltekit.assets%/logo.png" />
-		<title>DIPS Park</title>
-		<meta name="viewport" content="width=device-width" />
-		%sveltekit.head%
-	</head>
-	<body data-sveltekit-preload-data="hover">
-		<div style="display: contents">%sveltekit.body%</div>
-	</body>
+
+<head>
+	<meta charset="utf-8" />
+	<link rel="manifest" href="/manifest.json">
+	<link rel="icon" href="%sveltekit.assets%/logo.png" />
+	<title>DIPS Park</title>
+	<meta name="viewport" content="width=device-width" />
+	%sveltekit.head%
+</head>
+
+<body data-sveltekit-preload-data="hover">
+	<div style="display: contents">%sveltekit.body%</div>
+</body>
+
 </html>

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,0 +1,15 @@
+{
+    "name": "DIPS Park",
+    "description": "Everything you need to book a parking spot at DIPS Trondheim",
+    "display": "standalone",
+    "start_url": "/",
+    "id": "/",
+    "icons": [
+        {
+            "src": "logo.png",
+            "sizes": "159x159",
+            "type": "image/png",
+            "purpose": "any"
+        }
+    ]
+}


### PR DESCRIPTION
This pull request adds a `manifest.json` file making it possible to run this app as a progressive web app.

<img width="321" alt="image" src="https://github.com/ivarnm/dipspark/assets/1034073/0c74acc1-027e-4fb4-ad14-a2efccb758d1">

